### PR TITLE
Np 2498 handle unrecognized query parameters

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -14,7 +14,9 @@ exports.handler = async (event, context) => {
 }
 
 const errorResponse = (response, event) => {
-  const path = 'path' in event ? event.path : 'Undefined path'
+  const path = 'path' in event
+    ? 'queryStringParameters' in event ? event.path + '?' + event.queryStringParameters : event.path
+    : 'Undefined path'
   return {
     statusCode: response.code,
     headers: {

--- a/src/handler.js
+++ b/src/handler.js
@@ -14,9 +14,6 @@ exports.handler = async (event, context) => {
 }
 
 const errorResponse = (response, event) => {
-  const path = 'path' in event
-    ? 'queryStringParameters' in event ? event.path + '?' + event.queryStringParameters : event.path
-    : 'Undefined path'
   return {
     statusCode: response.code,
     headers: {
@@ -29,7 +26,7 @@ const errorResponse = (response, event) => {
         {
           status: response.code,
           detail: response.message,
-          instance: path
+          instance: getPath(event)
         }
       )
     )
@@ -48,9 +45,18 @@ const responseWithEmptyBody = () => {
   return response
 }
 
-const isInvalidValidEvent = (event) => !('path' in event && 'httpMethod' in event)
+const isInvalidValidEvent = (event) => !(hasPath(event) && 'httpMethod' in event)
 
 const isGetMethod = (event) => event.httpMethod.toUpperCase() === 'GET'
+
+const hasPath = (event) => 'path' in event
+
+const getPath = (event) => {
+  if (!hasPath(event)) {
+    return 'Undefined path'
+  }
+  return 'queryStringParameters' in event ? `${event.path}?${event.queryStringParameters}` : event.path
+}
 
 const hasQueryParameters = (event) => {
   return 'queryStringParameters' in event && event.queryStringParameters !== undefined

--- a/src/handler.js
+++ b/src/handler.js
@@ -26,7 +26,7 @@ const errorResponse = (response, event) => {
         {
           status: response.code,
           detail: response.message,
-          instance: getPath(event)
+          instance: getProblemInstance(event)
         }
       )
     )
@@ -51,7 +51,7 @@ const isGetMethod = (event) => event.httpMethod.toUpperCase() === 'GET'
 
 const hasPath = (event) => 'path' in event
 
-const getPath = (event) => {
+const getProblemInstance = (event) => {
   if (!hasPath(event)) {
     return 'Undefined path'
   }

--- a/src/handler.js
+++ b/src/handler.js
@@ -7,7 +7,7 @@ logger.info('Logger initialized')
 const routes = ['/journal', '/publisher']
 
 exports.handler = async (event, context) => {
-  if (isInvalidValidEvent(event)) {
+  if (isInvalidEvent(event)) {
     return errorResponse(createInternalServerErrorDetails(), event)
   }
   return isValidRequest(event) ? responseWithEmptyBody() : errorResponse(createErrorDetails(event), event)
@@ -45,7 +45,7 @@ const responseWithEmptyBody = () => {
   return response
 }
 
-const isInvalidValidEvent = (event) => !(hasPath(event) && 'httpMethod' in event)
+const isInvalidEvent = (event) => !(hasPath(event) && 'httpMethod' in event)
 
 const isGetMethod = (event) => event.httpMethod.toUpperCase() === 'GET'
 
@@ -80,8 +80,6 @@ const createBadRequestDetails = (event) => {
   return { code: httpStatus.BAD_REQUEST, message: `Your request cannot be processed because the supplied parameter(s) ${event.queryStringParameters} cannot be understood` }
 }
 
-const createErrorDetails = (event) => {
-  return isGetMethod(event)
-    ? hasQueryParameters(event) ? createBadRequestDetails(event) : createNotFoundDetails(event)
-    : createMethodNotAllowedDetails(event)
-}
+const problemsWithGetMethod = event => hasQueryParameters(event) ? createBadRequestDetails(event) : createNotFoundDetails(event)
+
+const createErrorDetails = (event) => isGetMethod(event) ? problemsWithGetMethod(event) : createMethodNotAllowedDetails(event)

--- a/src/tests/unit/handler.test.js
+++ b/src/tests/unit/handler.test.js
@@ -67,8 +67,6 @@ describe('Handler throws error when called with queryStringParameters', () => {
     const queryStringParameters = 'sample.query.string.parameter'
     const event = { path: '/journal', httpMethod: 'GET', queryStringParameters: queryStringParameters }
     const response = await handler(event)
-    expect(response.headers).to.have.property('Content-Type')
-    expect(response.headers['Content-Type']).to.equal('application/problem+json')
     expect(response.statusCode).to.equal(400)
     const responseBody = JSON.parse(response.body)
     expect(responseBody.instance).to.equal(`/journal?${queryStringParameters}`)
@@ -76,5 +74,22 @@ describe('Handler throws error when called with queryStringParameters', () => {
     expect(responseBody.detail).to.equal(`Your request cannot be processed because the supplied parameter(s) ${queryStringParameters} cannot be understood`)
     expect(responseBody.title).to.equal('Bad Request')
     expect(responseBody.type).to.equal('about:blank')
+  })
+})
+
+describe("Handler sets different 'Content-type' in respnse headers", () => {
+  it("handler returns 'Content-Type' 'application/json' when responsecode is 200", async function () {
+    const event = { path: '/journal', httpMethod: 'GET' }
+    const response = await handler(event)
+    expect(response.statusCode).to.equal(httpStatus.OK)
+    expect(response.headers).to.have.property('Content-Type')
+    expect(response.headers['Content-Type']).to.equal('application/json')
+  })
+  it("handler returns 'Content-Type' 'application/problem+json' when error occurs", async function () {
+    const event = { path: '/jornal', httpMethod: 'GET' }
+    const response = await handler(event)
+    expect(response.statusCode).to.equal(httpStatus.NOT_FOUND)
+    expect(response.headers).to.have.property('Content-Type')
+    expect(response.headers['Content-Type']).to.equal('application/problem+json')
   })
 })

--- a/src/tests/unit/handler.test.js
+++ b/src/tests/unit/handler.test.js
@@ -63,7 +63,7 @@ describe('Handler throws 405 when httpMethod is not GET', () => {
 })
 
 describe('Handler throws error when called with queryStringParameters', () => {
-  it('verifies response is error 400 and  has Bad Request Error message', async function () {
+  it('verifies response is error 400 and has Bad Request problem response', async function () {
     const queryStringParameters = 'sample.query.string.parameter'
     const event = { path: '/journal', httpMethod: 'GET', queryStringParameters: queryStringParameters }
     const response = await handler(event)
@@ -71,7 +71,7 @@ describe('Handler throws error when called with queryStringParameters', () => {
     expect(response.headers['Content-Type']).to.equal('application/problem+json')
     expect(response.statusCode).to.equal(400)
     const responseBody = JSON.parse(response.body)
-    expect(responseBody.instance).to.equal('/journal?sample.query.string.parameter')
+    expect(responseBody.instance).to.equal(`/journal?${queryStringParameters}`)
     expect(responseBody.status).to.equal(400)
     expect(responseBody.detail).to.equal(`Your request cannot be processed because the supplied parameter(s) ${queryStringParameters} cannot be understood`)
     expect(responseBody.title).to.equal('Bad Request')

--- a/src/tests/unit/handler.test.js
+++ b/src/tests/unit/handler.test.js
@@ -67,9 +67,11 @@ describe('Handler throws error when called with queryStringParameters', () => {
     const queryStringParameters = 'sample.query.string.parameter'
     const event = { path: '/journal', httpMethod: 'GET', queryStringParameters: queryStringParameters }
     const response = await handler(event)
+    expect(response.headers).to.have.property('Content-Type')
+    expect(response.headers['Content-Type']).to.equal('application/problem+json')
     expect(response.statusCode).to.equal(400)
     const responseBody = JSON.parse(response.body)
-    expect(responseBody.instance).to.equal('/journal')
+    expect(responseBody.instance).to.equal('/journal?sample.query.string.parameter')
     expect(responseBody.status).to.equal(400)
     expect(responseBody.detail).to.equal(`Your request cannot be processed because the supplied parameter(s) ${queryStringParameters} cannot be understood`)
     expect(responseBody.title).to.equal('Bad Request')

--- a/src/tests/unit/handler.test.js
+++ b/src/tests/unit/handler.test.js
@@ -61,3 +61,17 @@ describe('Handler throws 405 when httpMethod is not GET', () => {
     })
   ))
 })
+
+describe('Handler throws error when called with queryStringParameters', () => {
+  it('verifies response is error 400 and  has Bad Request Error message', async function () {
+    const event = { path: '/journal', httpMethod: 'GET', queryStringParameters: 'queryStringParameters' }
+    const response = await handler(event)
+    expect(response.statusCode).to.equal(400)
+    const responseBody = JSON.parse(response.body)
+    expect(responseBody.instance).to.equal('/journal')
+    expect(responseBody.status).to.equal(400)
+    expect(responseBody.detail).to.equal('Your request cannot be processed because the supplied parameter(s) "{parameters}" cannot be understood')
+    expect(responseBody.title).to.equal('Bad Request')
+    expect(responseBody.type).to.equal('about:blank')
+  })
+})

--- a/src/tests/unit/handler.test.js
+++ b/src/tests/unit/handler.test.js
@@ -64,13 +64,14 @@ describe('Handler throws 405 when httpMethod is not GET', () => {
 
 describe('Handler throws error when called with queryStringParameters', () => {
   it('verifies response is error 400 and  has Bad Request Error message', async function () {
-    const event = { path: '/journal', httpMethod: 'GET', queryStringParameters: 'queryStringParameters' }
+    const queryStringParameters = 'sample.query.string.parameter'
+    const event = { path: '/journal', httpMethod: 'GET', queryStringParameters: queryStringParameters }
     const response = await handler(event)
     expect(response.statusCode).to.equal(400)
     const responseBody = JSON.parse(response.body)
     expect(responseBody.instance).to.equal('/journal')
     expect(responseBody.status).to.equal(400)
-    expect(responseBody.detail).to.equal('Your request cannot be processed because the supplied parameter(s) "{parameters}" cannot be understood')
+    expect(responseBody.detail).to.equal(`Your request cannot be processed because the supplied parameter(s) ${queryStringParameters} cannot be understood`)
     expect(responseBody.title).to.equal('Bad Request')
     expect(responseBody.type).to.equal('about:blank')
   })


### PR DESCRIPTION
Always return error 400 when queryparameters is present in request. This will be followed with a PR that handles actual query parameters we accept. This ensures that queryparameters we don't accept returns a 400 bad request response.