### PR TITLE
Use volta to manage node environment

### DIFF
--- a/.github/workflows/node.js.yaml
+++ b/.github/workflows/node.js.yaml
@@ -7,17 +7,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [14.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
+    - uses: volta-cli/action@v1
+    - run: npm install
     - run: npm ci --prefix src
     - run: npm run build --if-present --prefix src
     - run: npm test  --prefix src

--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ You can find more information and examples about filtering Lambda function logs 
 the [SAM CLI Documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-logging.html)
 .
 
+## Development
+
+Node environment management is delegated to [Volta](https://volta.sh)
+
+To manage your node environment, follow Volta's [getting started](https://docs.volta.sh/guide/getting-started) instructions. 
+
 ## Tests
 
 Tests are defined in the `src/tests` folder in this project. Use NPM to install

--- a/src/package.json
+++ b/src/package.json
@@ -23,7 +23,6 @@
   "homepage": "https://github.com/BIBSYSDEV/nva-publication-channels#readme",
   "devDependencies": {
     "chai": "^4.3.4",
-    "dirty-chai": "^2.0.1",
     "eslint": "^7.25.0",
     "eslint-config-standard": "^16.0.2",
     "eslint-plugin-import": "^2.22.1",
@@ -37,5 +36,9 @@
     "http-problem-details": "^0.1.5",
     "http-status-codes": "^2.1.4",
     "pino": "^6.11.3"
+  },
+  "volta": {
+    "node": "14.17.0",
+    "npm": "6.14.13"
   }
 }


### PR DESCRIPTION
This PR delegates management of the node environment to volta.sh, which 
 - ensures that we are using the same version of node and npm across all environments

I also removed dirty-chai as it is no longer in use
