### PR TITLE
Add suggestion for route-spec handling

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "lint": "eslint . --ext .js",
     "lint:fix": "npm run lint -- --fix",
-    "mocha": "mocha --full-trace tests/unit/",
-    "test": "npm run lint && mocha tests/unit/",
+    "mocha": "mocha --full-trace \"tests/unit/**/*.js\"",
+    "test": "npm run lint && npm run mocha",
     "integ-test": "run lint && mocha tests/integration/",
     "coverage": "nyc --reporter=cobertura --reporter=text --reporter=html npm run test"
   },

--- a/src/routeSpec/QueryParameter.js
+++ b/src/routeSpec/QueryParameter.js
@@ -1,0 +1,23 @@
+'use strict'
+
+class QueryParameter {
+  /**
+     * Defines a query parameter for a route.
+     * @param {String} name
+     * @param {Boolean} required
+     */
+  constructor (name, required) {
+    this._name = name
+    this._required = required
+  }
+
+  get required () {
+    return this._required
+  }
+
+  get name () {
+    return this._name
+  }
+}
+
+module.exports = QueryParameter

--- a/src/routeSpec/RouteSpec.js
+++ b/src/routeSpec/RouteSpec.js
@@ -4,14 +4,14 @@ const _VALID_METHODS = ['CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 
 const _URI_SEGMENT_REGEX = '([a-zA-Z0-9\\$\\-_\\@\\.&\\+\\-\\!*"\'\\(\\)\\,](\\%[0-9a-fA-F]{2})?)+'
 const _PATH_PARAM_REGEX = `^${_URI_SEGMENT_REGEX}$`
 const _PATH_REGEX = `^\\/${_URI_SEGMENT_REGEX}$`
-const isValidPathDefinition = paths => paths.every(path => path.match(_PATH_REGEX))
-const isValidMethodDefinition = methods => methods.every(method => _VALID_METHODS.includes(method.toUpperCase()))
+const allPathsAreValid = paths => paths.every(path => path.match(_PATH_REGEX))
+const allMethodsAreValid = methods => methods.every(method => _VALID_METHODS.includes(method.toUpperCase()))
 const isValidPathParametersDefinition = pathParameters => pathParameters.every(param => param.match(_PATH_PARAM_REGEX))
 const isValidQueryParametersDefinition = queryParameters => queryParameters.every(param => param instanceof QueryParameter)
-const getPaths = paths => isValidPathDefinition(paths) ? paths : false
-const getMethods = methods => isValidMethodDefinition(methods) ? methods.map(method => method.toUpperCase()) : false
-const getPathParameters = pathParameters => isValidPathParametersDefinition(pathParameters) ? pathParameters : false
-const getQueryParameters = queryParameters => isValidQueryParametersDefinition(queryParameters) ? queryParameters : false
+const getPaths = paths => allPathsAreValid(paths) ? paths : () => { throw new Error('Invalid paths definition') }
+const getMethods = methods => allMethodsAreValid(methods) ? methods.map(method => method.toUpperCase()) : () => { throw new Error('Invalid methods definition') }
+const getPathParameters = pathParameters => isValidPathParametersDefinition(pathParameters) ? pathParameters : () => { throw new Error('Bad path parameters definition') }
+const getQueryParameters = queryParameters => isValidQueryParametersDefinition(queryParameters) ? queryParameters : () => { throw new Error('Bad query parameters definition') }
 
 class RouteSpec {
   /**
@@ -22,10 +22,10 @@ class RouteSpec {
    * @param {Array.<QueryParameter>} queryParameters
    */
   constructor (paths, methods, pathParameters, queryParameters) {
-    this._paths = getPaths(paths) || (() => { throw new Error('Invalid paths definition') })()
-    this._methods = getMethods(methods) || (() => { throw new Error('Invalid methods definition') })()
-    this._pathParameters = getPathParameters(pathParameters || []) || (() => { throw new Error('Bad path parameters definition') })()
-    this._queryParameters = getQueryParameters(queryParameters || []) || (() => { throw new Error('Bad query parameters definition') })()
+    this._paths = getPaths(paths)
+    this._methods = getMethods(methods)
+    this._pathParameters = getPathParameters(pathParameters || [])
+    this._queryParameters = getQueryParameters(queryParameters || [])
   }
 
   get queryParameters () {

--- a/src/routeSpec/RouteSpec.js
+++ b/src/routeSpec/RouteSpec.js
@@ -6,12 +6,13 @@ const _PATH_PARAM_REGEX = `^${_URI_SEGMENT_REGEX}$`
 const _PATH_REGEX = `^\\/${_URI_SEGMENT_REGEX}$`
 const allPathsAreValid = paths => paths.every(path => path.match(_PATH_REGEX))
 const allMethodsAreValid = methods => methods.every(method => _VALID_METHODS.includes(method.toUpperCase()))
-const isValidPathParametersDefinition = pathParameters => pathParameters.every(param => param.match(_PATH_PARAM_REGEX))
-const isValidQueryParametersDefinition = queryParameters => queryParameters.every(param => param instanceof QueryParameter)
+const convertNullToArray = input => (input === null || input === undefined) ? [] : input
+const isValidPathParametersDefinition = pathParameters => convertNullToArray(pathParameters).every(param => param.match(_PATH_PARAM_REGEX))
+const isValidQueryParametersDefinition = queryParameters => convertNullToArray(queryParameters).every(param => param instanceof QueryParameter)
 const getPaths = paths => allPathsAreValid(paths) ? paths : (() => { throw new Error('Invalid paths definition') })()
 const getMethods = methods => allMethodsAreValid(methods) ? methods.map(method => method.toUpperCase()) : (() => { throw new Error('Invalid methods definition') })()
-const getPathParameters = pathParameters => isValidPathParametersDefinition(pathParameters) ? pathParameters : (() => { throw new Error('Bad path parameters definition') })()
-const getQueryParameters = queryParameters => isValidQueryParametersDefinition(queryParameters) ? queryParameters : (() => { throw new Error('Bad query parameters definition') })()
+const getPathParameters = pathParameters => isValidPathParametersDefinition(pathParameters) ? convertNullToArray(pathParameters) : (() => { throw new Error('Bad path parameters definition') })()
+const getQueryParameters = queryParameters => isValidQueryParametersDefinition(queryParameters) ? convertNullToArray(queryParameters) : (() => { throw new Error('Bad query parameters definition') })()
 
 class RouteSpec {
   /**
@@ -24,8 +25,8 @@ class RouteSpec {
   constructor (paths, methods, pathParameters, queryParameters) {
     this._paths = getPaths(paths)
     this._methods = getMethods(methods)
-    this._pathParameters = getPathParameters(pathParameters || [])
-    this._queryParameters = getQueryParameters(queryParameters || [])
+    this._pathParameters = getPathParameters(pathParameters)
+    this._queryParameters = getQueryParameters(queryParameters)
   }
 
   get queryParameters () {

--- a/src/routeSpec/RouteSpec.js
+++ b/src/routeSpec/RouteSpec.js
@@ -1,0 +1,52 @@
+'use strict'
+const QueryParameter = require('./QueryParameter')
+const _VALID_METHODS = ['CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE']
+const _URI_SEGMENT_REGEX = '([a-zA-Z0-9\\$\\-_\\@\\.&\\+\\-\\!*"\'\\(\\)\\,](\\%[0-9]{2})?)+'
+const _PATH_PARAM_REGEX = `^${_URI_SEGMENT_REGEX}$`
+const _PATH_REGEX = `^\\/${_URI_SEGMENT_REGEX}$`
+const isValidPathDefinition = paths => paths.every(path => path.match(_PATH_REGEX))
+const isValidMethodDefinition = methods => methods.every(method => _VALID_METHODS.includes(method.toUpperCase()))
+const isValidPathParametersDefinition = pathParameters => pathParameters.every(param => param.match(_PATH_PARAM_REGEX))
+const isValidQueryParametersDefinition = queryParameters => queryParameters.every(param => param instanceof QueryParameter)
+const getPaths = paths => isValidPathDefinition(paths) ? paths : false
+const getMethods = methods => isValidMethodDefinition(methods) ? methods.map(method => method.toUpperCase()) : false
+const getPathParameters = pathParameters => isValidPathParametersDefinition(pathParameters) ? pathParameters : false
+const getQueryParameters = queryParameters => isValidQueryParametersDefinition(queryParameters) ? queryParameters : false
+
+class RouteSpec {
+  /**
+   * Defines a route and the parameters that can be used with the route.
+   * @param {Array.<String>} paths
+   * @param {Array.<String>} methods
+   * @param {Array.<String>} pathParameters
+   * @param {Array.<QueryParameter>} queryParameters
+   */
+  constructor (paths, methods, pathParameters, queryParameters) {
+    this._paths = getPaths(paths) || (() => { throw new Error('Invalid paths definition') })()
+    this._methods = getMethods(methods) || (() => { throw new Error('Invalid methods definition') })()
+    this._pathParameters = getPathParameters(pathParameters || []) || (() => { throw new Error('Bad path parameters definition') })()
+    this._queryParameters = getQueryParameters(queryParameters || []) || (() => { throw new Error('Bad query parameters definition') })()
+  }
+
+  get queryParameters () {
+    return this._queryParameters.map(param => param.name)
+  }
+
+  get pathParameters () {
+    return this._pathParameters
+  }
+
+  get obligatoryQueryParameters () {
+    return this._queryParameters.filter(param => param.required === true).map(param => param.name)
+  }
+
+  get methods () {
+    return this._methods
+  }
+
+  get paths () {
+    return this._paths
+  }
+}
+
+module.exports = RouteSpec

--- a/src/routeSpec/RouteSpec.js
+++ b/src/routeSpec/RouteSpec.js
@@ -8,10 +8,10 @@ const allPathsAreValid = paths => paths.every(path => path.match(_PATH_REGEX))
 const allMethodsAreValid = methods => methods.every(method => _VALID_METHODS.includes(method.toUpperCase()))
 const isValidPathParametersDefinition = pathParameters => pathParameters.every(param => param.match(_PATH_PARAM_REGEX))
 const isValidQueryParametersDefinition = queryParameters => queryParameters.every(param => param instanceof QueryParameter)
-const getPaths = paths => allPathsAreValid(paths) ? paths : () => { throw new Error('Invalid paths definition') }
-const getMethods = methods => allMethodsAreValid(methods) ? methods.map(method => method.toUpperCase()) : () => { throw new Error('Invalid methods definition') }
-const getPathParameters = pathParameters => isValidPathParametersDefinition(pathParameters) ? pathParameters : () => { throw new Error('Bad path parameters definition') }
-const getQueryParameters = queryParameters => isValidQueryParametersDefinition(queryParameters) ? queryParameters : () => { throw new Error('Bad query parameters definition') }
+const getPaths = paths => allPathsAreValid(paths) ? paths : (() => { throw new Error('Invalid paths definition') })()
+const getMethods = methods => allMethodsAreValid(methods) ? methods.map(method => method.toUpperCase()) : (() => { throw new Error('Invalid methods definition') })()
+const getPathParameters = pathParameters => isValidPathParametersDefinition(pathParameters) ? pathParameters : (() => { throw new Error('Bad path parameters definition') })()
+const getQueryParameters = queryParameters => isValidQueryParametersDefinition(queryParameters) ? queryParameters : (() => { throw new Error('Bad query parameters definition') })()
 
 class RouteSpec {
   /**

--- a/src/routeSpec/RouteSpec.js
+++ b/src/routeSpec/RouteSpec.js
@@ -1,7 +1,7 @@
 'use strict'
 const QueryParameter = require('./QueryParameter')
 const _VALID_METHODS = ['CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE']
-const _URI_SEGMENT_REGEX = '([a-zA-Z0-9\\$\\-_\\@\\.&\\+\\-\\!*"\'\\(\\)\\,](\\%[0-9]{2})?)+'
+const _URI_SEGMENT_REGEX = '([a-zA-Z0-9\\$\\-_\\@\\.&\\+\\-\\!*"\'\\(\\)\\,](\\%[0-9a-fA-F]{2})?)+'
 const _PATH_PARAM_REGEX = `^${_URI_SEGMENT_REGEX}$`
 const _PATH_REGEX = `^\\/${_URI_SEGMENT_REGEX}$`
 const isValidPathDefinition = paths => paths.every(path => path.match(_PATH_REGEX))

--- a/src/routeSpec/Routes.js
+++ b/src/routeSpec/Routes.js
@@ -1,0 +1,60 @@
+'use strict'
+
+class Routes {
+  /**
+   * Declares all of the Route specifications for the application
+   * @param {Array.<RouteSpec>} routeSpecs
+   */
+  constructor (routeSpecs) {
+    this._routeSpecs = routeSpecs
+  }
+
+  /**
+   * Matches events with matching Route specifications.
+   * @param {Object} event An AWS event
+   * @returns {RouteSpec} If a match is found
+   * @throws {Error} If no match is found
+   */
+  matches (event) {
+    const pathMatches = this._routeSpecs.filter(spec => this._hasPath(event, spec))
+    if (pathMatches.length < 1) throw new Error('Not Found')
+
+    const methodMatches = pathMatches.filter(spec => this._hasMethod(event, spec))
+    if (methodMatches.length < 1) throw new Error('Method Not Allowed')
+
+    const pathParamsMatches = methodMatches.filter(spec => this._hasPathParams(event, spec))
+    if (pathParamsMatches.length < 1) throw new Error('Not Found')
+
+    const queryMatches = pathParamsMatches.filter(spec => this._hasQueryParams(event, spec))
+    if (queryMatches < 1) throw new Error('Bad Request')
+
+    return (queryMatches.length === 1) ? pathMatches[0] : (() => { throw new Error('Internal server error') })()
+  }
+
+  _hasPath (event, route) {
+    return !!route.paths.includes(event.path)
+  }
+
+  _hasMethod (event, route) {
+    return route.methods.includes(event.httpMethod)
+  }
+
+  _hasPathParams (event, spec) {
+    const paramNames = Object.keys(event.pathParameters || []).sort()
+    return this._arraysEqual(spec.pathParameters, paramNames) === true
+  }
+
+  _hasQueryParams (event, spec) {
+    const paramNames = Object.keys(event.queryStringParameters || [])
+    return paramNames.every(param => spec.queryParameters.includes(param)) && spec.obligatoryQueryParameters.every(param => paramNames.includes(param))
+  }
+
+  _arraysEqual (array1, array2) {
+    const array2Sorted = array2.slice().sort()
+    return array1.length === array2.length && array1.slice().sort().every((value, index) => {
+      return value === array2Sorted[index]
+    })
+  }
+}
+
+module.exports = Routes

--- a/src/routeSpec/Routes.js
+++ b/src/routeSpec/Routes.js
@@ -28,7 +28,11 @@ class Routes {
     const queryMatches = pathParamsMatches.filter(spec => this._hasQueryParams(event, spec))
     if (queryMatches < 1) throw new Error('Bad Request')
 
-    return (queryMatches.length === 1) ? pathMatches[0] : (() => { throw new Error('Internal server error') })()
+    if (queryMatches.length !== 1) {
+      throw new Error('Internal server error')
+    }
+
+    return pathMatches[0]
   }
 
   _hasPath (event, route) {

--- a/src/tests/unit/routeSpec/RouteSpec.test.js
+++ b/src/tests/unit/routeSpec/RouteSpec.test.js
@@ -16,13 +16,13 @@ describe('Valid route specs are validated', () => {
 
 describe('Invalid paths are rejected', () => {
   it('throws error when a path does not start with a slash', async function () {
-    expect(() => new RouteSpec(['wrong'], ['GET'], [], [])).to.throw('Invalid paths definition')
+    expect(() => new RouteSpec(['noSlash'], ['GET'], [], [])).to.throw('Invalid paths definition')
   })
   it('throws error when a path starts with two slashes', async function () {
-    expect(() => new RouteSpec(['//wrong'], ['GET'], [], [])).to.throw('Invalid paths definition')
+    expect(() => new RouteSpec(['//twoSlashes'], ['GET'], [], [])).to.throw('Invalid paths definition')
   })
   it('throws error when a single path does not start with a slash', async function () {
-    expect(() => new RouteSpec(['/ok', 'wrong'], ['GET'], [], [])).to.throw('Invalid paths definition')
+    expect(() => new RouteSpec(['/ok', 'noSlash'], ['GET'], [], [])).to.throw('Invalid paths definition')
   })
 })
 

--- a/src/tests/unit/routeSpec/RouteSpec.test.js
+++ b/src/tests/unit/routeSpec/RouteSpec.test.js
@@ -1,0 +1,132 @@
+'use strict'
+
+const RouteSpec = require('../../../routeSpec/RouteSpec')
+const Routes = require('../../../routeSpec/Routes')
+const QueryParameter = require('../../../routeSpec/QueryParameter')
+const chai = require('chai')
+const expect = chai.expect
+
+const _SIMPLE_ROUTE_SPEC = new RouteSpec(['/journal'], ['GET'], [], [])
+
+describe('Valid route specs are validated', () => {
+  it('returns true when a spec is matched', async function () {
+    expect(_SIMPLE_ROUTE_SPEC.paths).to.include('/journal')
+  })
+})
+
+describe('Invalid paths are rejected', () => {
+  it('throws error when a path does not start with a slash', async function () {
+    expect(() => new RouteSpec(['wrong'], ['GET'], [], [])).to.throw('Invalid paths definition')
+  })
+  it('throws error when a path starts with two slashes', async function () {
+    expect(() => new RouteSpec(['//wrong'], ['GET'], [], [])).to.throw('Invalid paths definition')
+  })
+  it('throws error when a single path does not start with a slash', async function () {
+    expect(() => new RouteSpec(['/ok', 'wrong'], ['GET'], [], [])).to.throw('Invalid paths definition')
+  })
+})
+
+describe('Invalid path parameters are rejected', () => {
+  it('throws error when a path parameters contain illegal characters', async function () {
+    expect(() => new RouteSpec(['/ok'], ['GET'], [':wrong'], [])).to.throw('Bad path parameters definition')
+  })
+})
+
+describe('Null path parameters are converted to array', () => {
+  it('returns array when path parameters are null', async function () {
+    const pathParameters = new RouteSpec(['/ok'], ['GET'], null, []).pathParameters
+    expect(pathParameters).to.be.instanceof(Array)
+    expect(pathParameters).to.have.length(0)
+  })
+})
+
+describe('Null query parameters are converted to array', () => {
+  it('returns array when query parameters are null', async function () {
+    const queryParameters = new RouteSpec(['/ok'], ['GET'], [], null).queryParameters
+    expect(queryParameters).to.be.instanceof(Array)
+    expect(queryParameters).to.have.length(0)
+  })
+})
+
+describe('Invalid methods are rejected', () => {
+  it('throws error when a method is unrecognized', async function () {
+    expect(() => new RouteSpec(['/ok'], ['PORT'], [], [])).to.throw('Invalid methods definition')
+  })
+})
+
+describe('Invalid query parameter definitions are rejected', () => {
+  it('throws error when a query parameter is badly defined', async function () {
+    expect(() => new RouteSpec(['/ok'], ['POST'], [], [{ figs: 10 }])).to.throw('Bad query parameters definition')
+  })
+})
+
+describe('Valid events are recognized', () => {
+  it('returns true when path is matched', async function () {
+    const event = { path: '/journal', httpMethod: 'GET' }
+    const matches = new Routes([_SIMPLE_ROUTE_SPEC]).matches(event)
+    expect(matches).to.be.instanceof(RouteSpec)
+    expect(matches).to.equal(_SIMPLE_ROUTE_SPEC)
+  })
+  it('returns true when method is matched', () => {
+    const event = { path: '/journal', httpMethod: 'GET' }
+    const routes = new Routes([_SIMPLE_ROUTE_SPEC])
+    const matches = routes.matches(event)
+    expect(matches).to.be.instanceof(RouteSpec)
+    expect(matches).to.equal(_SIMPLE_ROUTE_SPEC)
+  })
+  it('returns true when no path parameters are present', () => {
+    const event = { path: '/journal', httpMethod: 'GET', pathParameters: null }
+    const routes = new Routes([_SIMPLE_ROUTE_SPEC])
+    const matches = routes.matches(event)
+    expect(matches).to.be.instanceof(RouteSpec)
+    expect(matches).to.equal(_SIMPLE_ROUTE_SPEC)
+  })
+  it('returns true when path parameters are matched', () => {
+    const event = { path: '/journal', httpMethod: 'GET', pathParameters: { hello: 'pounce', doggy: 'bland' } }
+    const routeSpec = new RouteSpec(['/journal'], ['GET'], ['hello', 'doggy'], [])
+    const routes = new Routes([routeSpec])
+    const matches = routes.matches(event)
+    expect(matches).to.be.instanceof(RouteSpec)
+    expect(matches).to.equal(routeSpec)
+  })
+  it('returns true when query parameters are matched', () => {
+    const event = { path: '/journal', httpMethod: 'GET', pathParameters: null, queryStringParameters: { hats: 'yes', suit: '44' } }
+    const routeSpec = new RouteSpec(['/journal'], ['GET'], [], [new QueryParameter('hats', true), new QueryParameter('suit', false)])
+    const routes = new Routes([routeSpec])
+    const matches = routes.matches(event)
+    expect(matches).to.be.instanceof(RouteSpec)
+    expect(matches).to.equal(routeSpec)
+  })
+})
+
+describe('Invalid events are recognized', () => {
+  it('returns Error when path is not matched', async function () {
+    const event = { path: '/publisher' }
+    const routes = new Routes([_SIMPLE_ROUTE_SPEC])
+    expect(() => routes.matches(event)).to.throw('Not Found')
+  })
+  it('returns Error when method is not matched', async function () {
+    [{ spec: _SIMPLE_ROUTE_SPEC, event: { path: '/journal', httpMethod: 'POST' } }, { spec: new RouteSpec(['/journal'], ['GET'], ['id', 'year'], null), event: { path: '/journal', httpMethod: 'POST', pathParameters: { id: 213123, year: 2020 } } }].forEach(pair => {
+      const routes = new Routes([pair.spec])
+      expect(() => routes.matches(pair.event)).to.throw('Method Not Allowed')
+    })
+  })
+  it('returns Error when path parameter is not matched', async function () {
+    const event = { path: '/journal', httpMethod: 'GET', pathParameters: [{ mean: 'hats' }] }
+    const routes = new Routes([_SIMPLE_ROUTE_SPEC])
+    expect(() => routes.matches(event)).to.throw('Not Found')
+  })
+  it('returns Error when query parameter is unrecognized', async function () {
+    const event = { path: '/journal', httpMethod: 'GET', pathParameters: null, queryStringParameters: { mean: 'hats' } }
+    const routes = new Routes([_SIMPLE_ROUTE_SPEC])
+    expect(() => routes.matches(event)).to.throw('Bad Request')
+  })
+})
+
+describe('Misconfiguration causes generic errors', () => {
+  it('returns Error when multiple routes match input', () => {
+    const event = { path: '/journal', httpMethod: 'GET', pathParameters: null, queryStringParameters: [] }
+    const routes = new Routes([_SIMPLE_ROUTE_SPEC, _SIMPLE_ROUTE_SPEC])
+    expect(() => routes.matches(event)).to.throw('Internal server error')
+  })
+})


### PR DESCRIPTION
Firstly, this is a large PR that contains a lot of functionality. It should probably have been broken down, but it made little sense to me to do it this way as it is in all aspects a refactoring step. If you are entirely against this approach, or the refactoring approach I envisage (see below), I will delete the PR and try to refactor directly.

- Adds a basic construct for a Route Specification, that allows us to create a valid route definition
- Requests can be validated against the specifications
- In a next step, the validation of requests can be delegated to the Routes module
- Finally, routes can return a formatted query specification that can be used in querying the remote resource