### PR TITLE
Making path take a string rather than array

### DIFF
--- a/src/routeSpec/RouteSpec.js
+++ b/src/routeSpec/RouteSpec.js
@@ -4,12 +4,12 @@ const _VALID_METHODS = ['CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 
 const _URI_SEGMENT_REGEX = '([a-zA-Z0-9\\$\\-_\\@\\.&\\+\\-\\!*"\'\\(\\)\\,](\\%[0-9a-fA-F]{2})?)+'
 const _PATH_PARAM_REGEX = `^${_URI_SEGMENT_REGEX}$`
 const _PATH_REGEX = `^\\/${_URI_SEGMENT_REGEX}$`
-const allPathsAreValid = paths => paths.every(path => path.match(_PATH_REGEX))
+const pathsIsValid = path => path.match(_PATH_REGEX)
 const allMethodsAreValid = methods => methods.every(method => _VALID_METHODS.includes(method.toUpperCase()))
 const convertNullToArray = input => (input === null || input === undefined) ? [] : input
 const isValidPathParametersDefinition = pathParameters => convertNullToArray(pathParameters).every(param => param.match(_PATH_PARAM_REGEX))
 const isValidQueryParametersDefinition = queryParameters => convertNullToArray(queryParameters).every(param => param instanceof QueryParameter)
-const getPaths = paths => allPathsAreValid(paths) ? paths : (() => { throw new Error('Invalid paths definition') })()
+const getPath = path => pathsIsValid(path) ? path : (() => { throw new Error('Invalid paths definition') })()
 const getMethods = methods => allMethodsAreValid(methods) ? methods.map(method => method.toUpperCase()) : (() => { throw new Error('Invalid methods definition') })()
 const getPathParameters = pathParameters => isValidPathParametersDefinition(pathParameters) ? convertNullToArray(pathParameters) : (() => { throw new Error('Bad path parameters definition') })()
 const getQueryParameters = queryParameters => isValidQueryParametersDefinition(queryParameters) ? convertNullToArray(queryParameters) : (() => { throw new Error('Bad query parameters definition') })()
@@ -17,13 +17,13 @@ const getQueryParameters = queryParameters => isValidQueryParametersDefinition(q
 class RouteSpec {
   /**
    * Defines a route and the parameters that can be used with the route.
-   * @param {Array.<String>} paths
+   * @param {String} path
    * @param {Array.<String>} methods
    * @param {Array.<String>} pathParameters
    * @param {Array.<QueryParameter>} queryParameters
    */
-  constructor (paths, methods, pathParameters, queryParameters) {
-    this._paths = getPaths(paths)
+  constructor (path, methods, pathParameters, queryParameters) {
+    this._path = getPath(path)
     this._methods = getMethods(methods)
     this._pathParameters = getPathParameters(pathParameters)
     this._queryParameters = getQueryParameters(queryParameters)
@@ -45,8 +45,8 @@ class RouteSpec {
     return this._methods
   }
 
-  get paths () {
-    return this._paths
+  get path () {
+    return this._path
   }
 }
 

--- a/src/routeSpec/RouteSpec.js
+++ b/src/routeSpec/RouteSpec.js
@@ -9,7 +9,7 @@ const allMethodsAreValid = methods => methods.every(method => _VALID_METHODS.inc
 const convertNullToArray = input => (input === null || input === undefined) ? [] : input
 const isValidPathParametersDefinition = pathParameters => convertNullToArray(pathParameters).every(param => param.match(_PATH_PARAM_REGEX))
 const isValidQueryParametersDefinition = queryParameters => convertNullToArray(queryParameters).every(param => param instanceof QueryParameter)
-const getPath = path => pathsIsValid(path) ? path : (() => { throw new Error('Invalid paths definition') })()
+const getPath = path => pathsIsValid(path) ? path : (() => { throw new Error('Invalid path definition') })()
 const getMethods = methods => allMethodsAreValid(methods) ? methods.map(method => method.toUpperCase()) : (() => { throw new Error('Invalid methods definition') })()
 const getPathParameters = pathParameters => isValidPathParametersDefinition(pathParameters) ? convertNullToArray(pathParameters) : (() => { throw new Error('Bad path parameters definition') })()
 const getQueryParameters = queryParameters => isValidQueryParametersDefinition(queryParameters) ? convertNullToArray(queryParameters) : (() => { throw new Error('Bad query parameters definition') })()

--- a/src/routeSpec/Routes.js
+++ b/src/routeSpec/Routes.js
@@ -36,7 +36,7 @@ class Routes {
   }
 
   _hasPath (event, route) {
-    return !!route.paths.includes(event.path)
+    return route.path === event.path
   }
 
   _hasMethod (event, route) {

--- a/src/tests/unit/routeSpec/RouteSpec.test.js
+++ b/src/tests/unit/routeSpec/RouteSpec.test.js
@@ -6,35 +6,32 @@ const QueryParameter = require('../../../routeSpec/QueryParameter')
 const chai = require('chai')
 const expect = chai.expect
 
-const _SIMPLE_ROUTE_SPEC = new RouteSpec(['/journal'], ['GET'], [], [])
+const _SIMPLE_ROUTE_SPEC = new RouteSpec('/journal', ['GET'], [], [])
 
 describe('Valid route specs are validated', () => {
   it('returns true when a spec is matched', async function () {
-    expect(_SIMPLE_ROUTE_SPEC.paths).to.include('/journal')
+    expect(_SIMPLE_ROUTE_SPEC.path).to.include('/journal')
   })
 })
 
 describe('Invalid paths are rejected', () => {
   it('throws error when a path does not start with a slash', async function () {
-    expect(() => new RouteSpec(['noSlash'], ['GET'], [], [])).to.throw('Invalid paths definition')
+    expect(() => new RouteSpec('noSlash', ['GET'], [], [])).to.throw('Invalid paths definition')
   })
   it('throws error when a path starts with two slashes', async function () {
-    expect(() => new RouteSpec(['//twoSlashes'], ['GET'], [], [])).to.throw('Invalid paths definition')
-  })
-  it('throws error when a single path does not start with a slash', async function () {
-    expect(() => new RouteSpec(['/ok', 'noSlash'], ['GET'], [], [])).to.throw('Invalid paths definition')
+    expect(() => new RouteSpec('//twoSlashes', ['GET'], [], [])).to.throw('Invalid paths definition')
   })
 })
 
 describe('Invalid path parameters are rejected', () => {
   it('throws error when a path parameters contain illegal characters', async function () {
-    expect(() => new RouteSpec(['/ok'], ['GET'], [':wrong'], [])).to.throw('Bad path parameters definition')
+    expect(() => new RouteSpec('/ok', ['GET'], [':wrong'], [])).to.throw('Bad path parameters definition')
   })
 })
 
 describe('Null path parameters are converted to array', () => {
   it('returns array when path parameters are null', async function () {
-    const pathParameters = new RouteSpec(['/ok'], ['GET'], null, []).pathParameters
+    const pathParameters = new RouteSpec('/ok', ['GET'], null, []).pathParameters
     expect(pathParameters).to.be.instanceof(Array)
     expect(pathParameters).to.have.length(0)
   })
@@ -42,7 +39,7 @@ describe('Null path parameters are converted to array', () => {
 
 describe('Null query parameters are converted to array', () => {
   it('returns array when query parameters are null', async function () {
-    const queryParameters = new RouteSpec(['/ok'], ['GET'], [], null).queryParameters
+    const queryParameters = new RouteSpec('/ok', ['GET'], [], null).queryParameters
     expect(queryParameters).to.be.instanceof(Array)
     expect(queryParameters).to.have.length(0)
   })
@@ -50,13 +47,13 @@ describe('Null query parameters are converted to array', () => {
 
 describe('Invalid methods are rejected', () => {
   it('throws error when a method is unrecognized', async function () {
-    expect(() => new RouteSpec(['/ok'], ['PORT'], [], [])).to.throw('Invalid methods definition')
+    expect(() => new RouteSpec('/ok', ['PORT'], [], [])).to.throw('Invalid methods definition')
   })
 })
 
 describe('Invalid query parameter definitions are rejected', () => {
   it('throws error when a query parameter is badly defined', async function () {
-    expect(() => new RouteSpec(['/ok'], ['POST'], [], [{ figs: 10 }])).to.throw('Bad query parameters definition')
+    expect(() => new RouteSpec('/ok', ['POST'], [], [{ figs: 10 }])).to.throw('Bad query parameters definition')
   })
 })
 
@@ -83,7 +80,7 @@ describe('Valid events are recognized', () => {
   })
   it('returns true when path parameters are matched', () => {
     const event = { path: '/journal', httpMethod: 'GET', pathParameters: { hello: 'pounce', doggy: 'bland' } }
-    const routeSpec = new RouteSpec(['/journal'], ['GET'], ['hello', 'doggy'], [])
+    const routeSpec = new RouteSpec('/journal', ['GET'], ['hello', 'doggy'], [])
     const routes = new Routes([routeSpec])
     const matches = routes.matches(event)
     expect(matches).to.be.instanceof(RouteSpec)
@@ -91,7 +88,7 @@ describe('Valid events are recognized', () => {
   })
   it('returns true when query parameters are matched', () => {
     const event = { path: '/journal', httpMethod: 'GET', pathParameters: null, queryStringParameters: { hats: 'yes', suit: '44' } }
-    const routeSpec = new RouteSpec(['/journal'], ['GET'], [], [new QueryParameter('hats', true), new QueryParameter('suit', false)])
+    const routeSpec = new RouteSpec('/journal', ['GET'], [], [new QueryParameter('hats', true), new QueryParameter('suit', false)])
     const routes = new Routes([routeSpec])
     const matches = routes.matches(event)
     expect(matches).to.be.instanceof(RouteSpec)
@@ -106,7 +103,7 @@ describe('Invalid events are recognized', () => {
     expect(() => routes.matches(event)).to.throw('Not Found')
   })
   it('returns Error when method is not matched', async function () {
-    [{ spec: _SIMPLE_ROUTE_SPEC, event: { path: '/journal', httpMethod: 'POST' } }, { spec: new RouteSpec(['/journal'], ['GET'], ['id', 'year'], null), event: { path: '/journal', httpMethod: 'POST', pathParameters: { id: 213123, year: 2020 } } }].forEach(pair => {
+    [{ spec: _SIMPLE_ROUTE_SPEC, event: { path: '/journal', httpMethod: 'POST' } }, { spec: new RouteSpec('/journal', ['GET'], ['id', 'year'], null), event: { path: '/journal', httpMethod: 'POST', pathParameters: { id: 213123, year: 2020 } } }].forEach(pair => {
       const routes = new Routes([pair.spec])
       expect(() => routes.matches(pair.event)).to.throw('Method Not Allowed')
     })

--- a/src/tests/unit/routeSpec/RouteSpec.test.js
+++ b/src/tests/unit/routeSpec/RouteSpec.test.js
@@ -16,10 +16,10 @@ describe('Valid route specs are validated', () => {
 
 describe('Invalid paths are rejected', () => {
   it('throws error when a path does not start with a slash', async function () {
-    expect(() => new RouteSpec('noSlash', ['GET'], [], [])).to.throw('Invalid paths definition')
+    expect(() => new RouteSpec('noSlash', ['GET'], [], [])).to.throw('Invalid path definition')
   })
   it('throws error when a path starts with two slashes', async function () {
-    expect(() => new RouteSpec('//twoSlashes', ['GET'], [], [])).to.throw('Invalid paths definition')
+    expect(() => new RouteSpec('//twoSlashes', ['GET'], [], [])).to.throw('Invalid path definition')
   })
 })
 


### PR DESCRIPTION
This is the first PR in a series that implements the use of Routes to filter requests.

- Migrates paths {Array.<String>} to path {String}