### PR TITLE
Add template to routespec

### DIFF
--- a/src/routeSpec/RouteSpec.js
+++ b/src/routeSpec/RouteSpec.js
@@ -1,5 +1,6 @@
 'use strict'
 const QueryParameter = require('./QueryParameter')
+const fs = require('fs')
 const _VALID_METHODS = ['CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE']
 const _URI_SEGMENT_REGEX = '([a-zA-Z0-9\\$\\-_\\@\\.&\\+\\-\\!*"\'\\(\\)\\,](\\%[0-9a-fA-F]{2})?)+'
 const _PATH_PARAM_REGEX = `^${_URI_SEGMENT_REGEX}$`
@@ -13,6 +14,7 @@ const getPath = path => pathsIsValid(path) ? path : (() => { throw new Error('In
 const getMethod = method => methodIsValid(method) ? method.toUpperCase() : (() => { throw new Error('Invalid method definition') })()
 const getPathParameters = pathParameters => isValidPathParametersDefinition(pathParameters) ? convertNullToArray(pathParameters) : (() => { throw new Error('Bad path parameters definition') })()
 const getQueryParameters = queryParameters => isValidQueryParametersDefinition(queryParameters) ? convertNullToArray(queryParameters) : (() => { throw new Error('Bad query parameters definition') })()
+const getTemplate = template => fs.existsSync(template) ? template : (() => { throw new Error('Bad template definition: ' + template) })()
 
 class RouteSpec {
   /**
@@ -21,12 +23,18 @@ class RouteSpec {
    * @param {String} method
    * @param {Array.<String>} pathParameters
    * @param {Array.<QueryParameter>} queryParameters
+   * @param {String} template
    */
-  constructor (path, method, pathParameters, queryParameters) {
+  constructor (path, method, pathParameters, queryParameters, template) {
     this._path = getPath(path)
     this._method = getMethod(method)
     this._pathParameters = getPathParameters(pathParameters)
     this._queryParameters = getQueryParameters(queryParameters)
+    this._template = getTemplate(template)
+  }
+
+  get template () {
+    return this._template
   }
 
   get queryParameters () {

--- a/src/tests/unit/routeSpec/RouteSpec.test.js
+++ b/src/tests/unit/routeSpec/RouteSpec.test.js
@@ -6,7 +6,8 @@ const QueryParameter = require('../../../routeSpec/QueryParameter')
 const chai = require('chai')
 const expect = chai.expect
 
-const _SIMPLE_ROUTE_SPEC = new RouteSpec('/journal', 'GET', [], [])
+const _VALID_TEMPLATE = 'queryTemplates/query_journal_template.json'
+const _SIMPLE_ROUTE_SPEC = new RouteSpec('/journal', 'GET', [], [], _VALID_TEMPLATE)
 
 describe('Valid route specs are validated', () => {
   it('returns true when a spec is matched', async function () {
@@ -16,22 +17,22 @@ describe('Valid route specs are validated', () => {
 
 describe('Invalid paths are rejected', () => {
   it('throws error when a path does not start with a slash', async function () {
-    expect(() => new RouteSpec('noSlash', 'GET', [], [])).to.throw('Invalid path definition')
+    expect(() => new RouteSpec('noSlash', 'GET', [], [], _VALID_TEMPLATE)).to.throw('Invalid path definition')
   })
   it('throws error when a path starts with two slashes', async function () {
-    expect(() => new RouteSpec('//twoSlashes', 'GET', [], [])).to.throw('Invalid path definition')
+    expect(() => new RouteSpec('//twoSlashes', 'GET', [], [], _VALID_TEMPLATE)).to.throw('Invalid path definition')
   })
 })
 
 describe('Invalid path parameters are rejected', () => {
   it('throws error when a path parameters contain illegal characters', async function () {
-    expect(() => new RouteSpec('/ok', 'GET', [':wrong'], [])).to.throw('Bad path parameters definition')
+    expect(() => new RouteSpec('/ok', 'GET', [':wrong'], [], _VALID_TEMPLATE)).to.throw('Bad path parameters definition')
   })
 })
 
 describe('Null path parameters are converted to array', () => {
   it('returns array when path parameters are null', async function () {
-    const pathParameters = new RouteSpec('/ok', 'GET', null, []).pathParameters
+    const pathParameters = new RouteSpec('/ok', 'GET', null, [], _VALID_TEMPLATE).pathParameters
     expect(pathParameters).to.be.instanceof(Array)
     expect(pathParameters).to.have.length(0)
   })
@@ -39,7 +40,7 @@ describe('Null path parameters are converted to array', () => {
 
 describe('Null query parameters are converted to array', () => {
   it('returns array when query parameters are null', async function () {
-    const queryParameters = new RouteSpec('/ok', 'GET', [], null).queryParameters
+    const queryParameters = new RouteSpec('/ok', 'GET', [], null, _VALID_TEMPLATE).queryParameters
     expect(queryParameters).to.be.instanceof(Array)
     expect(queryParameters).to.have.length(0)
   })
@@ -47,13 +48,26 @@ describe('Null query parameters are converted to array', () => {
 
 describe('Invalid methods are rejected', () => {
   it('throws error when a method is unrecognized', async function () {
-    expect(() => new RouteSpec('/ok', 'PORT', [], [])).to.throw('Invalid method definition')
+    expect(() => new RouteSpec('/ok', 'PORT', [], [], _VALID_TEMPLATE)).to.throw('Invalid method definition')
   })
 })
 
 describe('Invalid query parameter definitions are rejected', () => {
   it('throws error when a query parameter is badly defined', async function () {
-    expect(() => new RouteSpec('/ok', 'POST', [], [{ figs: 10 }])).to.throw('Bad query parameters definition')
+    expect(() => new RouteSpec('/ok', 'POST', [], [{ figs: 10 }], _VALID_TEMPLATE)).to.throw('Bad query parameters definition')
+  })
+})
+
+describe('Valid templates are validated', async function () {
+  it('returns true when a spec is validated', () => {
+    expect(_SIMPLE_ROUTE_SPEC.template).to.include(_VALID_TEMPLATE)
+  })
+})
+
+describe('Invalid templates are rejected', async function () {
+  it('throws error when a spec is contains a template that does not exist', () => {
+    const _INVALID_TEMPLATE = 'not_exist.json'
+    expect(() => new RouteSpec('/ok', 'GET', [], [], _INVALID_TEMPLATE)).to.throw('Bad template definition: ' + _INVALID_TEMPLATE)
   })
 })
 
@@ -80,7 +94,7 @@ describe('Valid events are recognized', () => {
   })
   it('returns true when path parameters are matched', () => {
     const event = { path: '/journal', httpMethod: 'GET', pathParameters: { hello: 'pounce', doggy: 'bland' } }
-    const routeSpec = new RouteSpec('/journal', 'GET', ['hello', 'doggy'], [])
+    const routeSpec = new RouteSpec('/journal', 'GET', ['hello', 'doggy'], [], _VALID_TEMPLATE)
     const routes = new Routes([routeSpec])
     const matches = routes.matches(event)
     expect(matches).to.be.instanceof(RouteSpec)
@@ -88,7 +102,7 @@ describe('Valid events are recognized', () => {
   })
   it('returns true when query parameters are matched', () => {
     const event = { path: '/journal', httpMethod: 'GET', pathParameters: null, queryStringParameters: { hats: 'yes', suit: '44' } }
-    const routeSpec = new RouteSpec('/journal', 'GET', [], [new QueryParameter('hats', true), new QueryParameter('suit', false)])
+    const routeSpec = new RouteSpec('/journal', 'GET', [], [new QueryParameter('hats', true), new QueryParameter('suit', false)], _VALID_TEMPLATE)
     const routes = new Routes([routeSpec])
     const matches = routes.matches(event)
     expect(matches).to.be.instanceof(RouteSpec)
@@ -103,7 +117,7 @@ describe('Invalid events are recognized', () => {
     expect(() => routes.matches(event)).to.throw('Not Found')
   })
   it('returns Error when method is not matched', async function () {
-    [{ spec: _SIMPLE_ROUTE_SPEC, event: { path: '/journal', httpMethod: 'POST' } }, { spec: new RouteSpec('/journal', 'GET', ['id', 'year'], null), event: { path: '/journal', httpMethod: 'POST', pathParameters: { id: 213123, year: 2020 } } }].forEach(pair => {
+    [{ spec: _SIMPLE_ROUTE_SPEC, event: { path: '/journal', httpMethod: 'POST' } }, { spec: new RouteSpec('/journal', 'GET', ['id', 'year'], null, _VALID_TEMPLATE), event: { path: '/journal', httpMethod: 'POST', pathParameters: { id: 213123, year: 2020 } } }].forEach(pair => {
       const routes = new Routes([pair.spec])
       expect(() => routes.matches(pair.event)).to.throw('Method Not Allowed')
     })


### PR DESCRIPTION
This is the fourth PR and should be reviewed when the previous three are merged into main

- Adds the template to the routespec, 
  - [TBD] which allows it to be later returned when a routespec matches a given event input