### PR TITLE
Refactor error handling path error

### DIFF
--- a/src/errors/PathDefinitionError.js
+++ b/src/errors/PathDefinitionError.js
@@ -1,0 +1,9 @@
+class PathDefinitionError extends Error {
+  constructor (message) {
+    super(message)
+    this.name = this.constructor.name
+    Error.captureStackTrace(this, this.constructor)
+  }
+}
+
+module.exports = PathDefinitionError

--- a/src/errors/PathDefinitionError.js
+++ b/src/errors/PathDefinitionError.js
@@ -1,6 +1,6 @@
 class PathDefinitionError extends Error {
-  constructor (message) {
-    super(message)
+  constructor (path) {
+    super(`Invalid path definition: ${path}. The path should begin with a slash and be a valid URI segment`)
     this.name = this.constructor.name
     Error.captureStackTrace(this, this.constructor)
   }

--- a/src/routeSpec/RouteSpec.js
+++ b/src/routeSpec/RouteSpec.js
@@ -1,6 +1,7 @@
 'use strict'
 const QueryParameter = require('./QueryParameter')
 const fs = require('fs')
+const PathDefinitionError = require('../errors/PathDefinitionError')
 const _VALID_METHODS = ['CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE']
 const _URI_SEGMENT_REGEX = '([a-zA-Z0-9\\$\\-_\\@\\.&\\+\\-\\!*"\'\\(\\)\\,](\\%[0-9a-fA-F]{2})?)+'
 const _PATH_PARAM_REGEX = `^${_URI_SEGMENT_REGEX}$`
@@ -10,7 +11,7 @@ const methodIsValid = method => _VALID_METHODS.includes(method.toUpperCase())
 const convertNullToArray = input => (input === null || input === undefined) ? [] : input
 const isValidPathParametersDefinition = pathParameters => convertNullToArray(pathParameters).every(param => param.match(_PATH_PARAM_REGEX))
 const isValidQueryParametersDefinition = queryParameters => convertNullToArray(queryParameters).every(param => param instanceof QueryParameter)
-const getPath = path => pathsIsValid(path) ? path : (() => { throw new Error('Invalid path definition') })()
+const getPath = path => pathsIsValid(path) ? path : (() => { throw new PathDefinitionError('Invalid path definition: ' + path) })()
 const getMethod = method => methodIsValid(method) ? method.toUpperCase() : (() => { throw new Error('Invalid method definition') })()
 const getPathParameters = pathParameters => isValidPathParametersDefinition(pathParameters) ? convertNullToArray(pathParameters) : (() => { throw new Error('Bad path parameters definition') })()
 const getQueryParameters = queryParameters => isValidQueryParametersDefinition(queryParameters) ? convertNullToArray(queryParameters) : (() => { throw new Error('Bad query parameters definition') })()

--- a/src/routeSpec/RouteSpec.js
+++ b/src/routeSpec/RouteSpec.js
@@ -11,7 +11,7 @@ const methodIsValid = method => _VALID_METHODS.includes(method.toUpperCase())
 const convertNullToArray = input => (input === null || input === undefined) ? [] : input
 const isValidPathParametersDefinition = pathParameters => convertNullToArray(pathParameters).every(param => param.match(_PATH_PARAM_REGEX))
 const isValidQueryParametersDefinition = queryParameters => convertNullToArray(queryParameters).every(param => param instanceof QueryParameter)
-const getPath = path => pathsIsValid(path) ? path : (() => { throw new PathDefinitionError('Invalid path definition: ' + path) })()
+const getPath = path => pathsIsValid(path) ? path : (() => { throw new PathDefinitionError(path) })()
 const getMethod = method => methodIsValid(method) ? method.toUpperCase() : (() => { throw new Error('Invalid method definition') })()
 const getPathParameters = pathParameters => isValidPathParametersDefinition(pathParameters) ? convertNullToArray(pathParameters) : (() => { throw new Error('Bad path parameters definition') })()
 const getQueryParameters = queryParameters => isValidQueryParametersDefinition(queryParameters) ? convertNullToArray(queryParameters) : (() => { throw new Error('Bad query parameters definition') })()

--- a/src/tests/unit/routeSpec/RouteSpec.test.js
+++ b/src/tests/unit/routeSpec/RouteSpec.test.js
@@ -19,10 +19,10 @@ describe('Valid route specs are validated', () => {
 
 describe('Invalid paths are rejected', () => {
   it('throws error when a path does not start with a slash', async function () {
-    expect(() => new RouteSpec(_INVALID_PATH_NO_SLASH, 'GET', [], [], _VALID_TEMPLATE)).to.throw('Invalid path definition: ' + _INVALID_PATH_NO_SLASH)
+    expect(() => new RouteSpec(_INVALID_PATH_NO_SLASH, 'GET', [], [], _VALID_TEMPLATE)).to.throw(`Invalid path definition: ${_INVALID_PATH_NO_SLASH}. The path should begin with a slash and be a valid URI segment`)
   })
   it('throws error when a path starts with two slashes', async function () {
-    expect(() => new RouteSpec(_INVALID_PATH_TWO_SLASHES, 'GET', [], [], _VALID_TEMPLATE)).to.throw('Invalid path definition: ' + _INVALID_PATH_TWO_SLASHES)
+    expect(() => new RouteSpec(_INVALID_PATH_TWO_SLASHES, 'GET', [], [], _VALID_TEMPLATE)).to.throw(`Invalid path definition: ${_INVALID_PATH_TWO_SLASHES}. The path should begin with a slash and be a valid URI segment`)
   })
 })
 

--- a/src/tests/unit/routeSpec/RouteSpec.test.js
+++ b/src/tests/unit/routeSpec/RouteSpec.test.js
@@ -18,11 +18,12 @@ describe('Valid route specs are validated', () => {
 })
 
 describe('Invalid paths are rejected', () => {
-  it('throws error when a path does not start with a slash', async function () {
-    expect(() => new RouteSpec(_INVALID_PATH_NO_SLASH, 'GET', [], [], _VALID_TEMPLATE)).to.throw(`Invalid path definition: ${_INVALID_PATH_NO_SLASH}. The path should begin with a slash and be a valid URI segment`)
-  })
-  it('throws error when a path starts with two slashes', async function () {
-    expect(() => new RouteSpec(_INVALID_PATH_TWO_SLASHES, 'GET', [], [], _VALID_TEMPLATE)).to.throw(`Invalid path definition: ${_INVALID_PATH_TWO_SLASHES}. The path should begin with a slash and be a valid URI segment`)
+  [_INVALID_PATH_NO_SLASH, _INVALID_PATH_TWO_SLASHES].forEach(path => {
+    it('throws error when a path does not match expectations', async function () {
+      const error = () => new RouteSpec(path, 'GET', [], [], _VALID_TEMPLATE)
+      const expected = `Invalid path definition: ${path}. The path should begin with a slash and be a valid URI segment`
+      expect(error).to.throw(expected)
+    })
   })
 })
 

--- a/src/tests/unit/routeSpec/RouteSpec.test.js
+++ b/src/tests/unit/routeSpec/RouteSpec.test.js
@@ -8,6 +8,8 @@ const expect = chai.expect
 
 const _VALID_TEMPLATE = 'queryTemplates/query_journal_template.json'
 const _SIMPLE_ROUTE_SPEC = new RouteSpec('/journal', 'GET', [], [], _VALID_TEMPLATE)
+const _INVALID_PATH_NO_SLASH = 'noSlash'
+const _INVALID_PATH_TWO_SLASHES = '//twoSlashes'
 
 describe('Valid route specs are validated', () => {
   it('returns true when a spec is matched', async function () {
@@ -17,10 +19,10 @@ describe('Valid route specs are validated', () => {
 
 describe('Invalid paths are rejected', () => {
   it('throws error when a path does not start with a slash', async function () {
-    expect(() => new RouteSpec('noSlash', 'GET', [], [], _VALID_TEMPLATE)).to.throw('Invalid path definition')
+    expect(() => new RouteSpec(_INVALID_PATH_NO_SLASH, 'GET', [], [], _VALID_TEMPLATE)).to.throw('Invalid path definition: ' + _INVALID_PATH_NO_SLASH)
   })
   it('throws error when a path starts with two slashes', async function () {
-    expect(() => new RouteSpec('//twoSlashes', 'GET', [], [], _VALID_TEMPLATE)).to.throw('Invalid path definition')
+    expect(() => new RouteSpec(_INVALID_PATH_TWO_SLASHES, 'GET', [], [], _VALID_TEMPLATE)).to.throw('Invalid path definition: ' + _INVALID_PATH_TWO_SLASHES)
   })
 })
 


### PR DESCRIPTION
This PR is number five in the refactoring and should be reviewed after the previous four are merged into main

- Adds a new Error, PathDefinitionError to help debugging
- Improves information in error message