### PR TITLE
PublisherId not publisher name and updated test

### DIFF
--- a/src/queryTemplates/JournalTitleSearch.js
+++ b/src/queryTemplates/JournalTitleSearch.js
@@ -23,7 +23,8 @@ class JournalTitleSearch {
       variable.WEBSITE,
       variable.LEVEL,
       variable.ACTIVE,
-      variable.PUBLISHER
+      variable.PUBLISHER,
+      variable.PUBLISHER_ID
     ]
     return new QueryTemplate(Table.JOURNAL, [filter], projection, [variable.ORIGINAL_TITLE], size)
   }

--- a/src/tests/unit/handler.test.js
+++ b/src/tests/unit/handler.test.js
@@ -426,7 +426,10 @@ describe('Handler returns application/ld+json with deployment path as part of id
   const queryParameters = { query: 'irrelevant', year: '2020' }
   const testEvent = createTestEvent(contentType, 'GET', '/journal', null, queryParameters, domain)
   it(`returns 200 OK and deployment path as part of id for ${testEvent.path} when it has publisher `, async () => {
-    nsdMockReturns(httpStatus.OK, journalRemoteResponseDataWithPublisher)
+    const publisherId = 'publisher-1'
+    const returnValueWithPublisher = JSON.parse(journalRemoteResponseDataWithPublisher)
+    returnValueWithPublisher[0]['Forlag id'] = publisherId
+    nsdMockReturns(httpStatus.OK, JSON.stringify(returnValueWithPublisher))
     const response = await handler.handler(testEvent)
     expect(response.statusCode).to.equal(httpStatus.OK)
     expect(response.headers['Content-Type']).to.equal('application/ld+json')
@@ -434,23 +437,23 @@ describe('Handler returns application/ld+json with deployment path as part of id
     hits.forEach(hit => {
       expect(hit.id).to.startsWith(expectedDomainPrefix)
       expect(hit.publisherId).to.startsWith(expectedDomainPrefix)
+      expect(hit.publisherId).to.contain(publisherId)
     })
   })
   it(`returns 200 OK and deployment path as part of id for ${testEvent.path} when it does not have publisher `, async () => {
     const publisherId = [null, undefined, '']
-    publisherId.forEach(async (publisherId) => {
-      const returnValue = journalRemoteResponseDataWithoutPublisher
-      returnValue['forlag id'] = publisherId
-      nsdMockReturns(httpStatus.OK, returnValue)
+    for (const publisherId1 of publisherId) {
+      const returnValue = JSON.parse(journalRemoteResponseDataWithoutPublisher)
+      returnValue['forlag id'] = publisherId1
+      nsdMockReturns(httpStatus.OK, JSON.stringify(returnValue))
       const response = await handler.handler(testEvent)
       expect(response.statusCode).to.equal(httpStatus.OK)
       expect(response.headers['Content-Type']).to.equal('application/ld+json')
       const hits = JSON.parse(response.body)
       hits.forEach(hit => {
         expect(hit.id).to.startsWith(expectedDomainPrefix)
-        expect(hit.publisher).to.equal(null)
         expect(hit.publisherId).to.equal(null)
       })
-    })
+    }
   })
 })

--- a/src/tests/unit/handler.test.js
+++ b/src/tests/unit/handler.test.js
@@ -441,10 +441,11 @@ describe('Handler returns application/ld+json with deployment path as part of id
     })
   })
   it(`returns 200 OK and deployment path as part of id for ${testEvent.path} when it does not have publisher `, async () => {
-    const publisherId = [null, undefined, '']
-    for (const publisherId1 of publisherId) {
+    const expectedPublisherId = null
+    const inputForlagIds = [null, undefined, '']
+    inputForlagIds.forEach(async (inputForlagId) => {
       const returnValue = JSON.parse(journalRemoteResponseDataWithoutPublisher)
-      returnValue['forlag id'] = publisherId1
+      returnValue['forlag id'] = inputForlagId
       nsdMockReturns(httpStatus.OK, JSON.stringify(returnValue))
       const response = await handler.handler(testEvent)
       expect(response.statusCode).to.equal(httpStatus.OK)
@@ -452,8 +453,8 @@ describe('Handler returns application/ld+json with deployment path as part of id
       const hits = JSON.parse(response.body)
       hits.forEach(hit => {
         expect(hit.id).to.startsWith(expectedDomainPrefix)
-        expect(hit.publisherId).to.equal(null)
+        expect(hit.publisherId).to.equal(expectedPublisherId)
       })
-    }
+    })
   })
 })


### PR DESCRIPTION
Using publisherId ('Forlag id' as NSD calls it) and not publisher name('Utgiver' as NSD calls it) for identifying publisher of a journal. Test is updated to actuall test this - was an hidden exception within test...